### PR TITLE
fix for Setting metadata issue 222

### DIFF
--- a/samples/bucketLock.js
+++ b/samples/bucketLock.js
@@ -34,7 +34,9 @@ async function setRetentionPolicy(bucketName, retentionPeriod) {
     .bucket(bucketName)
     .setRetentionPeriod(retentionPeriod);
   console.log(
-    `Bucket ${bucketName} retention period set for ${metadata.retentionPolicy.retentionPeriod} seconds.`
+    `Bucket ${bucketName} retention period set for ${
+      metadata.retentionPolicy.retentionPeriod
+    } seconds.`
   );
   // [END storage_set_retention_policy]
 }
@@ -99,7 +101,9 @@ async function lockRetentionPolicy(bucketName) {
     .lock(unlockedMetadata.metageneration);
   console.log(`Retention policy for ${bucketName} is now locked.`);
   console.log(
-    `Retention policy effective as of ${lockedMetadata.retentionPolicy.effectiveTime}`
+    `Retention policy effective as of ${
+      lockedMetadata.retentionPolicy.effectiveTime
+    }`
   );
 
   return lockedMetadata;

--- a/src/bucket.ts
+++ b/src/bucket.ts
@@ -3098,8 +3098,8 @@ class Bucket extends ServiceObject {
 
     const contentType = mime.contentType(path.basename(pathString));
 
-    if (contentType && !options.metadata.contentType) {
-      options.metadata.contentType = contentType;
+    if (contentType && !options.metadata!.contentType) {
+      options.metadata!.contentType = contentType;
     }
 
     if (options.resumable != null && typeof options.resumable === 'boolean') {

--- a/test/bucket.ts
+++ b/test/bucket.ts
@@ -52,7 +52,7 @@ class FakeFile {
   bucket: Bucket;
   name: string;
   options: FileOptions;
-  metadata: {};
+  metadata: Metadata;
   createWriteStream: Function;
   isSameFile = () => false;
   constructor(bucket: Bucket, name: string, options?: FileOptions) {
@@ -2092,7 +2092,10 @@ describe('Bucket', () => {
         ws.write = () => true;
         setImmediate(() => {
           const expectedContentType = 'application/json; charset=utf-8';
-          assert.strictEqual(options.metadata.contentType, expectedContentType);
+          assert.strictEqual(
+            options.metadata!.contentType,
+            expectedContentType
+          );
           done();
         });
         return ws;
@@ -2108,7 +2111,10 @@ describe('Bucket', () => {
         ws.write = () => true;
         setImmediate(() => {
           const expectedContentType = 'text/plain; charset=utf-8';
-          assert.strictEqual(options.metadata.contentType, expectedContentType);
+          assert.strictEqual(
+            options.metadata!.contentType,
+            expectedContentType
+          );
           done();
         });
         return ws;
@@ -2140,7 +2146,7 @@ describe('Bucket', () => {
         ws.write = () => true;
         setImmediate(() => {
           assert.strictEqual(
-            options.metadata.contentType,
+            options.metadata!.contentType,
             metadata.contentType
           );
           done();


### PR DESCRIPTION


Due to poor metadata option object structure, user is facing difficulty/confusion to set custom metadata for file.

in this PR, new type is introduce name as `FileMetadata` with property `customMetadata`.
with method overloading user will provide metadata of type `FileMetadata` which will be convert into object which need to be supply to actual function of library.

With this user can be easily differentiate between *file metadata* and *file custom metadata*.

